### PR TITLE
Stop stream download on mobile without reloading page - Fixes #18

### DIFF
--- a/public_html/js/player.js
+++ b/public_html/js/player.js
@@ -8,21 +8,27 @@ function defaultPlayer() {
 
 // When you hit the play button
 function playerToggle() {
+  // Whether the browser claims to be a mobile device.
+  var mobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
   var stream = document.getElementById("stream");
 
   if (stream.paused) {
-	// Set the stream source back to what it should be
-	stream.src = "http://198.37.25.127:8000/cadence1"; // Make sure this stays current, otherwise the stream will not resume playing
+	if (mobile) {
+	  // Set the stream source back to what it should be
+	  stream.src = "http://198.37.25.127:8000/cadence1"; // Make sure this stays current, otherwise the stream will not resume playing
+	}
 	// Reload and play the stream
 	stream.load();
     stream.play();
     document.getElementById("playerToggle").innerHTML = "❚❚";
   } else {
-	// Set the stream source to an empty URL that claims to be an OGG
-	stream.src = URL.createObjectURL(new Blob([], {type:"application/ogg"}));
-	// And reload the stream (it is now paused, since it it playing nothing)
+	if (mobile) {
+	  // Set the stream source to an empty URL that claims to be an OGG
+	  stream.src = URL.createObjectURL(new Blob([], {type:"application/ogg"}));
+	  // And reload the stream (it is now paused, since it it playing nothing)
+	  stream.load();
+	}
 	stream.load();
-       
     document.getElementById("playerToggle").innerHTML = "►";
   }
 }

--- a/public_html/js/player.js
+++ b/public_html/js/player.js
@@ -11,15 +11,17 @@ function playerToggle() {
   var stream = document.getElementById("stream");
 
   if (stream.paused) {
+	// Set the stream source back to what it should be
+	stream.src = "http://198.37.25.127:8000/cadence1"; // Make sure this stays current, otherwise the stream will not resume playing
+	// Reload and play the stream
+	stream.load();
     stream.play();
     document.getElementById("playerToggle").innerHTML = "❚❚";
   } else {
-    // Reloads the entire page (the old way) if on a mobile device so it doesnt keep loading in the background. 
-    if (/Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent)) {
-      location.reload(); // wew wew
-    } else {
-      stream.load(); // wew 
-    }
+	// Set the stream source to an empty URL that claims to be an OGG
+	stream.src = URL.createObjectURL(new Blob([], {type:"application/ogg"}));
+	// And reload the stream (it is now paused, since it it playing nothing)
+	stream.load();
        
     document.getElementById("playerToggle").innerHTML = "►";
   }

--- a/public_html/js/player.js
+++ b/public_html/js/player.js
@@ -4,6 +4,10 @@ function defaultPlayer() {
   document.getElementById("volume").value = 0.77;
   var volume = document.getElementById("stream");
   volume.volume = vol;
+  
+  // If on mobile, only preload stream metadata
+  if (/Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent))
+    document.getElementById("stream").preload="metadata";
 }
 
 // When you hit the play button


### PR DESCRIPTION
The browser will now be instructed to load a nonexistent OGG while the stream is paused on mobile.

Also, don't preload the stream audio before playing on mobile - Just its metadata.